### PR TITLE
[BUGFIX] Fix copy'n'paste error in the badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # TDD seed project
 
-[![Build Status](https://travis-ci.org/oliverklee/insecurity.svg?branch=master)](https://travis-ci.org/oliverklee/insecurity)
-[![Latest Stable Version](https://poser.pugx.org/oliverklee/insecurity/v/stable.svg)](https://packagist.org/packages/oliverklee/insecurity)
-[![Total Downloads](https://poser.pugx.org/oliverklee/insecurity/downloads.svg)](https://packagist.org/packages/oliverklee/insecurity)
-[![Latest Unstable Version](https://poser.pugx.org/oliverklee/insecurity/v/unstable.svg)](https://packagist.org/packages/oliverklee/insecurity)
-[![License](https://poser.pugx.org/oliverklee/insecurity/license.svg)](https://packagist.org/packages/oliverklee/insecurity)
+[![Build Status](https://travis-ci.org/oliverklee/tdd-seed.svg?branch=master)](https://travis-ci.org/oliverklee/tdd-seed)
+[![Latest Stable Version](https://poser.pugx.org/oliverklee/tdd-seed/v/stable.svg)](https://packagist.org/packages/oliverklee/tdd-seed)
+[![Total Downloads](https://poser.pugx.org/oliverklee/tdd-seed/downloads.svg)](https://packagist.org/packages/oliverklee/tdd-seed)
+[![Latest Unstable Version](https://poser.pugx.org/oliverklee/tdd-seed/v/unstable.svg)](https://packagist.org/packages/oliverklee/tdd-seed)
+[![License](https://poser.pugx.org/oliverklee/tdd-seed/license.svg)](https://packagist.org/packages/oliverklee/tdd-seed)
 
 
 This is a starter repository for a project with PHPUnit.


### PR DESCRIPTION
The badges still pointed to another project.