### PR TITLE
[BUGFIX] Remove the vendor directory from Travis CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 
 cache:
   directories:
-  - vendor
   - $HOME/.composer/cache
 
 before_install:


### PR DESCRIPTION
This resolves problems with stale dependencies.