### PR TITLE
[BUGFIX] Keep GitHub actions on Composer 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install composer dependencies"
         run: |
+          composer selfupdate --1
           composer install --no-ansi --no-interaction --no-progress
           composer show
       - name: "Run tests"
@@ -88,6 +89,7 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install composer dependencies"
         run: |
+          composer selfupdate --1
           composer install --no-ansi --no-interaction --no-progress
           composer show
       - name: "Run tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.2 (#19)
 
 ### Fixed
+- Keep GitHub actions on Composer 1 (#32)
 - Make compatible with Composer 2 (#31)
 - Fix the casing of the vfsstream package (#5)


### PR DESCRIPTION
As long as we are compatible with PHP 7.1, we need to keep using
an old version of `infection/infection` and cannot use Composer 2
with that.