### PR TITLE
[TASK] Stop mentioning the PHP version requirements in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a starter repository for a project with PHPUnit.
 
 #### Local PHP
 
-You will need a local PHP (>= 7.1) installation with Composer.
+You will need a local PHP installation with Composer.
 
 If you would like to use Infection for mutation testing, you will also need
 Xdebug.


### PR DESCRIPTION
Having this in the `composer.json` should be enough.