### PR TITLE
[BUGFIX] Stop using curly braces for string indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.2 (#19)
 
 ### Fixed
+- Stop using curly braces for string indices (#47)
 - Keep GitHub actions on Composer 1 (#32)
 - Make compatible with Composer 2 (#31)
 - Fix the casing of the vfsstream package (#5)

--- a/src/Compression/RunLengthEncoder.php
+++ b/src/Compression/RunLengthEncoder.php
@@ -81,13 +81,13 @@ class RunLengthEncoder implements CompressorInterface
         $payloadLength = strlen($payload);
         $position = 0;
         while ($position < $payloadLength) {
-            $currentByte = $payload{$position};
+            $currentByte = $payload[$position];
             if ($currentByte !== self::MARKER) {
                 $uncompressedData .= $currentByte;
                 $position++;
             } else {
-                $repetitions = ord($payload{$position + 1});
-                $repeatable = $payload{$position + 2};
+                $repetitions = ord($payload[$position + 1]);
+                $repeatable = $payload[$position + 2];
                 $uncompressedData .= str_repeat($repeatable, $repetitions);
                 $position += 3;
             }


### PR DESCRIPTION
Curly braces for string indices have been deprecated in recent PHP
versions. Brackets it is now.