### PR TITLE
[BUGFIX] Stop covering interfaces

### DIFF
--- a/tests/Unit/Sniffer/SnifferInterfaceTest.php
+++ b/tests/Unit/Sniffer/SnifferInterfaceTest.php
@@ -9,7 +9,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecySubjectInterface;
 
 /**
- * @covers \OliverKlee\TddSeed\Sniffer\SnifferInterface
+ * @coversNothing
  */
 final class SnifferInterfaceTest extends TestCase
 {


### PR DESCRIPTION
Interfaces cannot be marked as covered.